### PR TITLE
Revise Accessibility Profile Badges documentation

### DIFF
--- a/get-involved/profile-badges/index.md
+++ b/get-involved/profile-badges/index.md
@@ -1,29 +1,35 @@
-# Profile Badges
+# Accessibility Profile Badges
 
-On your personal WordPress.org profile, badges are added based on your contributions to the WordPress project. [Learn more about Profile Badges](https://make.wordpress.org/meta/handbook/tutorials-guides/profile-badges/).
+This page offers comprehensive information about Accessibility Team [Profile Badges](https://make.wordpress.org/meta/handbook/tutorials-guides/profile-badges/) and the process for requesting these badges for your WordPress.org profile.
+
 
 ## Make Accessibility Contributor Profile Badge Criteria
 
 A contributor to the Make Accessible Team can be recognized for their contribution/contributions to the Accessibility Contributor Badge. Contributions can include:
 
-- Facilitating a bug-scrub session;
-- Commit, Comment on, or report accessibility issues to the WordPress open-source project on [GitHub](https://github.com/wordpress) or on [Trac](https://core.trac.wordpress.org/);
-- Assist the Make Accessible Team with the Weekly Meeting with administrative work such as posting an agenda or writing a follow-up for the meeting;
-- Update, suggest an edit, or draft a new documents in the Accessibility Team Handbook;
+- Facilitating a bug-scrub session.
+- Commit, Comment on, or report accessibility issues to the WordPress open-source project on [GitHub](https://github.com/wordpress) or on [Trac](https://core.trac.wordpress.org/).
+- Assist the Make Accessible Team with the Weekly Meeting with administrative work such as posting an agenda or writing a follow-up for the meeting.
+- Update, suggest an edit, or draft a new documents in the Accessibility Team Handbook.
 - Contribute to the accessibility of the WordPress.org network of sites, including OpenVerse, Learn.wordpress.org, wordpress.tv, or any of the other sites.
 
-If you believe you’ve earned the Contributor profile badge, post a request in the #accessibility Slack channel and somebody will follow up.
 
 ## Make Accessibility Team Profile Badge Criteria
 
-To receive a Team Profile Badge with the Make WordPress Accessible Team, you must actively contribute regularly or take a leadership role in the team.
+If you have served as a Accessibility Team Rep or have provided consistent substantial contributions to the Test Team, you are eligible for the Accessibility Team badge. These contributions include:
 
-This includes:
+- Participating in, contributing to, or moderating weekly team bugs scrubs.
+- Regularly commit, comment on, and report accessibility issues to the WordPress open-source project on [GitHub](https://github.com/wordpress) or on [Trac](https://core.trac.wordpress.org/).
+- Actively serve as Make WordPress Accessible Team Representative.
+- Attend and participate in Make WordPress Accessible Team meetings (currently bi-weekly).
+- Lead the Accessibility Table at a Contributor Day at a WordCamp.
 
-- Participating in, contributing to, or moderating weekly team bugs scrubs;
-- Regularly commit, comment on, and report accessibility issues to the WordPress open-source project on [GitHub](https://github.com/wordpress) or on [Trac](https://core.trac.wordpress.org/);
-- Actively serve as Make WordPress Accessible Team Representative;
-- Attend and participate in Make WordPress Accessible Team meetings (currently bi-weekly);
-- Lead the Accessibility Table at a Contributor Day at a WordCamp
 
-Profile Badges for this team are awarded manually for both Contributor or Teams. If you believe you’ve earned a Profile Badge, post a message in the #accessibility Slack channel and somebody will follow up.
+## Requesting a Accessibility Profile Badge
+
+If you meet the criteria above, please request a badge using the buttons below. Very important: Kindly include all the links to resources that demonstrate you have met the criteria mentioned above.
+
+- [Contributor Badge](https://profiles.wordpress.org/associations/accessibility-contributor/)
+- [Team Badge](https://profiles.wordpress.org/associations/accessibility-team/)
+
+Profile Badges for this team are awarded manually for both Contributor or Teams. If you believe you’ve earned a Profile Badge, post a message in the [`#accessibility`](https://wordpress.slack.com/archives/accessibility) Slack channel and somebody will follow up.

--- a/get-involved/profile-badges/index.md
+++ b/get-involved/profile-badges/index.md
@@ -1,6 +1,6 @@
 # Accessibility Profile Badges
 
-This page offers comprehensive information about Accessibility Team [Profile Badges](https://make.wordpress.org/meta/handbook/tutorials-guides/profile-badges/) and the process for requesting these badges for your WordPress.org profile.
+This page offers information about Accessibility Contributor and Team [Profile Badges](https://make.wordpress.org/meta/handbook/tutorials-guides/profile-badges/) and the process for requesting these badges for your WordPress.org profile.
 
 
 ## Make Accessibility Contributor Profile Badge Criteria
@@ -10,13 +10,13 @@ A contributor to the Make Accessible Team can be recognized for their contributi
 - Facilitating a bug-scrub session.
 - Commit, Comment on, or report accessibility issues to the WordPress open-source project on [GitHub](https://github.com/wordpress) or on [Trac](https://core.trac.wordpress.org/).
 - Assist the Make Accessible Team with the Weekly Meeting with administrative work such as posting an agenda or writing a follow-up for the meeting.
-- Update, suggest an edit, or draft a new documents in the Accessibility Team Handbook.
+- Update, suggest an edit, or draft a new documents in the [Accessibility Team Handbook](https://make.wordpress.org/accessibility/handbook/) or the [WordPress Accessibility Documentation](https://wpaccessibility.org/)
 - Contribute to the accessibility of the WordPress.org network of sites, including OpenVerse, Learn.wordpress.org, wordpress.tv, or any of the other sites.
 
 
 ## Make Accessibility Team Profile Badge Criteria
 
-If you have served as a Accessibility Team Rep or have provided consistent substantial contributions to the Test Team, you are eligible for the Accessibility Team badge. These contributions include:
+If you have take a leadership role or have provided consistent substantial contributions to the Accessibility Team, you are eligible for the Accessibility Team badge. These contributions include:
 
 - Participating in, contributing to, or moderating weekly team bugs scrubs.
 - Regularly commit, comment on, and report accessibility issues to the WordPress open-source project on [GitHub](https://github.com/wordpress) or on [Trac](https://core.trac.wordpress.org/).
@@ -30,6 +30,5 @@ If you have served as a Accessibility Team Rep or have provided consistent subst
 If you meet the criteria above, please request a badge using the buttons below. Very important: Kindly include all the links to resources that demonstrate you have met the criteria mentioned above.
 
 - [Contributor Badge](https://profiles.wordpress.org/associations/accessibility-contributor/)
-- [Team Badge](https://profiles.wordpress.org/associations/accessibility-team/)
 
 Profile Badges for this team are awarded manually for both Contributor or Teams. If you believe you’ve earned a Profile Badge, post a message in the [`#accessibility`](https://wordpress.slack.com/archives/accessibility) Slack channel and somebody will follow up.


### PR DESCRIPTION
Expanded and clarified information about Accessibility Team profile badges, including updated criteria for Contributor and Team badges, and added instructions and links for requesting badges. Improved formatting and provided more comprehensive guidance for contributors.

Fixed: #3 