### PR TITLE
Fixing grammatical error: `a new documents` → `a new document`

### DIFF
--- a/get-involved/profile-badges/index.md
+++ b/get-involved/profile-badges/index.md
@@ -10,7 +10,7 @@ A contributor to the Make Accessible Team can be recognized for their contributi
 - Facilitating a bug-scrub session.
 - Commit, Comment on, or report accessibility issues to the WordPress open-source project on [GitHub](https://github.com/wordpress) or on [Trac](https://core.trac.wordpress.org/).
 - Assist the Make Accessible Team with the Weekly Meeting with administrative work such as posting an agenda or writing a follow-up for the meeting.
-- Update, suggest an edit, or draft a new documents in the [Accessibility Team Handbook](https://make.wordpress.org/accessibility/handbook/) or the [WordPress Accessibility Documentation](https://wpaccessibility.org/)
+- Update, suggest an edit, or draft a new document in the [Accessibility Team Handbook](https://make.wordpress.org/accessibility/handbook/) or the [WordPress Accessibility Documentation](https://wpaccessibility.org/)
 - Contribute to the accessibility of the WordPress.org network of sites, including OpenVerse, Learn.wordpress.org, wordpress.tv, or any of the other sites.
 
 


### PR DESCRIPTION
## Summary
This PR fixes a minor grammatical error in `accessibility-team-handbook/get-involved/profile-badges/index.md` file.

## Before
> Update, suggest an edit, or draft a new documents in the Accessibility Team Handbook or the WordPress Accessibility Documentation.

## After
> Update, suggest an edit, or draft a new document in the Accessibility Team Handbook or the WordPress Accessibility Documentation.

## Checklist
- [x] Grammar corrected
- [x] Sentence meaning unchanged
- [x] No other edits introduced

## Related issue
Closes #9 